### PR TITLE
Ajusta a remessa do Santander para o que está descrito no layout

### DIFF
--- a/lib/brcobranca/remessa/cnab400/santander.rb
+++ b/lib/brcobranca/remessa/cnab400/santander.rb
@@ -45,7 +45,25 @@ module Brcobranca
         # @return [String]
         #
         def complemento
-          '58'.rjust(294, ' ')
+          '058'.rjust(279, ' ')
+        end
+
+        def monta_header
+          # CAMPO                 TAMANHO    VALOR
+          # tipo do registro      [1]        0
+          # operacao              [1]        1
+          # literal remessa       [7]        REMESSA
+          # Código do serviço     [2]        01
+          # cod. servico          [15]       COBRANCA
+          # info. conta           [20]
+          # empresa mae           [30]
+          # cod. banco            [3]
+          # nome banco            [15]
+          # data geracao          [6]        formato DDMMAA
+          # zeros                 [16]
+          # complemento registro  [278]
+          # num. sequencial       [6]        000001
+          "01REMESSA01COBRANCA       #{info_conta}#{empresa_mae.to_s.ljust(30, ' ')}#{cod_banco}#{nome_banco}#{data_geracao}000000000000000#{complemento}000001"
         end
 
         # Detalhe do arquivo
@@ -145,6 +163,19 @@ module Brcobranca
           detalhe << ''.rjust(1, ' ')                                       # Brancos                               X[1]
           detalhe << sequencial.to_s.rjust(6, '0')                          # numero do registro no arquivo         9[06]
           detalhe.upcase
+        end
+
+        def monta_trailer(sequencial)
+          documentos = "#{pagamentos.count.to_s.rjust(6, '0')}"
+          total = sprintf "%.2f", pagamentos.map(&:valor).inject(:+)
+
+          # CAMPO               TAMANHO   VALOR
+          # código registro     [1]       9
+          # quant. documentos   [6]
+          # valor total titulos [13]
+          # zeros               [374]     0
+          # num. sequencial     [6]
+          "9#{documentos}#{total.to_s.somente_numeros.rjust(13, "0")}#{''.rjust(374, '0')}#{sequencial.to_s.rjust(6, '0')}"
         end
       end
     end

--- a/spec/brcobranca/remessa/cnab400/santander_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/santander_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
       expect(nome_banco.strip).to eq 'SANTANDER'
     end
 
-    it 'complemento deve retornar 294 caracteres' do
-      expect(santander_cnab400.complemento.size).to eq 294
+    it 'complemento deve retornar 279 caracteres' do
+      expect(santander_cnab400.complemento.size).to eq 279
     end
 
     it 'info_conta deve retornar com 20 posicoes as informacoes da conta' do
@@ -110,6 +110,17 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
         expect(detalhe[126..138]).to eq '0000000019990'                # valor do titulo
         expect(detalhe[220..233]).to eq '00012345678901'               # documento do pagador
         expect(detalhe[234..263]).to eq 'NOME'.ljust(30, ' ')          # nome do pagador
+      end
+    end
+
+    context 'trailer' do
+      it 'informacoes devem estar posicionadas corretamente no trailer' do
+        trailer = santander_cnab400.monta_trailer "3"
+        expect(trailer[0]).to eq '9'                        # código registro
+        expect(trailer[1..6]).to eq '000001'                # quant. registros
+        expect(trailer[7..19]).to eq '0000000019990'        # valor total dos titulos
+        expect(trailer[20..393]).to eq ''.rjust(374, '0')   # zeros
+        expect(trailer[394..399]).to eq '000003'            # num. sequencial
       end
     end
   end

--- a/spec/support/shared_examples/cnab400.rb
+++ b/spec/support/shared_examples/cnab400.rb
@@ -69,7 +69,9 @@ shared_examples_for 'cnab400' do
     it 'informacoes devem estar posicionadas corretamente no trailer' do
       trailer = objeto.monta_trailer 3
       expect(trailer[0]).to eq '9'                       # identificacao registro
-      expect(trailer[1..393]).to eq ''.rjust(393, ' ')   # brancos
+      if subject.class != Brcobranca::Remessa::Cnab400::Santander
+        expect(trailer[1..393]).to eq ''.rjust(393, ' ')   # brancos
+      end
       expect(trailer[394..399]).to eq '000003'           # numero sequencial do registro
     end
   end


### PR DESCRIPTION
- Ajusta o header adicionando os zeros necessários após a data
- Ajusta o trailer para que tenha a quantidade de pagamentos e o valor total dos títulos.
