### PR TITLE
Ajusta remessa santander

### DIFF
--- a/lib/brcobranca/remessa/cnab400/santander.rb
+++ b/lib/brcobranca/remessa/cnab400/santander.rb
@@ -173,8 +173,8 @@ module Brcobranca
           detalhe << pagamento.uf_sacado                                    # uf do pagador                         X[02]
           detalhe << pagamento.nome_avalista.rjust(30, ' ')                 # Sacador/Mensagens                     X[40]
           detalhe << ''.rjust(1, ' ')                                       # Brancos                               X[1]
-          detalhe << ''.rjust(1, ' ')                                       # Identificador do Complemento          X[1]
-          detalhe << ''.rjust(2, ' ')                                       # Complemento                           9[2]
+          detalhe << identificador_movimento_complemento                    # Identificador do Complemento          X[1]
+          detalhe << movimento_complemento                                  # Complemento                           9[2]
           detalhe << ''.rjust(6, ' ')                                       # Brancos                               X[06]
           # Se identificacao_ocorrencia = 06
           detalhe << '00'.rjust(2, ' ')                                     # Número de dias para protesto          9[02]
@@ -183,13 +183,18 @@ module Brcobranca
           detalhe.upcase
         end
 
-        # Total de linhas (pagamentos + header + trailer)
-        #
-        # @return [String]
-        #
-        def total_linhas
-          documentos = pagamentos.count + 2
-          "#{documentos.to_s.rjust(6, '0')}"
+        def identificador_movimento_complemento
+          return 'I' if conta_padrao_novo?
+          ''.rjust(1, ' ')
+        end
+
+        def movimento_complemento
+          return "#{conta_corrente[8]}#{digito_conta}" if conta_padrao_novo?
+          ''.rjust(2, ' ')
+        end
+
+        def conta_padrao_novo?
+          conta_corrente.present? && conta_corrente.length > 8
         end
 
         # Valor total de todos os títulos
@@ -215,7 +220,7 @@ module Brcobranca
           # valor total titulos [13]
           # zeros               [374]     0
           # num. sequencial     [6]
-          "9#{total_linhas}#{total_titulos}#{''.rjust(374, '0')}#{sequencial.to_s.rjust(6, '0')}"
+          "9#{sequencial.to_s.rjust(6, '0')}#{total_titulos}#{''.rjust(374, '0')}#{sequencial.to_s.rjust(6, "0")}"
         end
       end
     end

--- a/lib/brcobranca/remessa/cnab400/santander.rb
+++ b/lib/brcobranca/remessa/cnab400/santander.rb
@@ -40,12 +40,29 @@ module Brcobranca
           codigo_transmissao.rjust(20, ' ')
         end
 
+        # Zeros do header
+        #
+        # @return [String]
+        #
+        def zeros
+          "".ljust(16, "0")
+        end
+
+
         # Complemento do header
         #
         # @return [String]
         #
         def complemento
-          '058'.rjust(279, ' ')
+          "".ljust(275, " ")
+        end
+
+        # Numero da versão da remessa
+        #
+        # @return [String]
+        #
+        def versao
+          "058"
         end
 
         def monta_header
@@ -61,9 +78,10 @@ module Brcobranca
           # nome banco            [15]
           # data geracao          [6]        formato DDMMAA
           # zeros                 [16]
-          # complemento registro  [278]
+          # complemento registro  [275]
+          # versao                [3]
           # num. sequencial       [6]        000001
-          "01REMESSA01COBRANCA       #{info_conta}#{empresa_mae.to_s.ljust(30, ' ')}#{cod_banco}#{nome_banco}#{data_geracao}000000000000000#{complemento}000001"
+          "01REMESSA01COBRANCA       #{info_conta}#{empresa_mae.to_s.ljust(30, ' ')}#{cod_banco}#{nome_banco}#{data_geracao}#{zeros}#{complemento}#{versao}000001"
         end
 
         # Detalhe do arquivo

--- a/lib/brcobranca/remessa/cnab400/santander.rb
+++ b/lib/brcobranca/remessa/cnab400/santander.rb
@@ -183,17 +183,39 @@ module Brcobranca
           detalhe.upcase
         end
 
-        def monta_trailer(sequencial)
-          documentos = "#{pagamentos.count.to_s.rjust(6, '0')}"
-          total = sprintf "%.2f", pagamentos.map(&:valor).inject(:+)
+        # Total de linhas (pagamentos + header + trailer)
+        #
+        # @return [String]
+        #
+        def total_linhas
+          documentos = pagamentos.count + 2
+          "#{documentos.to_s.rjust(6, '0')}"
+        end
 
+        # Valor total de todos os títulos
+        #
+        # @return [String]
+        #
+        def total_titulos
+          total = sprintf "%.2f", pagamentos.map(&:valor).inject(:+)
+          total.to_s.somente_numeros.rjust(13, "0")
+        end
+
+        # Trailer do arquivo remessa
+        #
+        # @param sequencial
+        #        num. sequencial do registro no arquivo
+        #
+        # @return [String]
+        #
+        def monta_trailer(sequencial)
           # CAMPO               TAMANHO   VALOR
           # código registro     [1]       9
           # quant. documentos   [6]
           # valor total titulos [13]
           # zeros               [374]     0
           # num. sequencial     [6]
-          "9#{documentos}#{total.to_s.somente_numeros.rjust(13, "0")}#{''.rjust(374, '0')}#{sequencial.to_s.rjust(6, '0')}"
+          "9#{total_linhas}#{total_titulos}#{''.rjust(374, '0')}#{sequencial.to_s.rjust(6, '0')}"
         end
       end
     end

--- a/spec/brcobranca/remessa/cnab400/santander_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/santander_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
       it 'informacoes devem estar posicionadas corretamente no trailer' do
         trailer = santander_cnab400.monta_trailer "3"
         expect(trailer[0]).to eq '9'                        # código registro
-        expect(trailer[1..6]).to eq '000001'                # quant. registros
+        expect(trailer[1..6]).to eq '000003'                # quant. total de linhas
         expect(trailer[7..19]).to eq '0000000019990'        # valor total dos titulos
         expect(trailer[20..393]).to eq ''.rjust(374, '0')   # zeros
         expect(trailer[394..399]).to eq '000003'            # num. sequencial

--- a/spec/brcobranca/remessa/cnab400/santander_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/santander_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
   end
 
   context 'formatacoes dos valores' do
-    it 'cod_banco deve ser 341' do
+    it 'cod_banco deve ser 033' do
       expect(santander_cnab400.cod_banco).to eq '033'
     end
 
@@ -78,8 +78,8 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
       expect(nome_banco.strip).to eq 'SANTANDER'
     end
 
-    it 'complemento deve retornar 279 caracteres' do
-      expect(santander_cnab400.complemento.size).to eq 279
+    it 'complemento deve retornar 275 caracteres' do
+      expect(santander_cnab400.complemento.size).to eq 275
     end
 
     it 'info_conta deve retornar com 20 posicoes as informacoes da conta' do
@@ -95,10 +95,13 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
     context 'header' do
       it 'informacoes devem estar posicionadas corretamente no header' do
         header = santander_cnab400.monta_header
-        expect(header[1]).to eq '1'                            # tipo operacao (1 = remessa)
-        expect(header[2..8]).to eq 'REMESSA'                   # literal da operacao
+        expect(header[1]).to eq '1'                                 # tipo operacao (1 = remessa)
+        expect(header[2..8]).to eq 'REMESSA'                        # literal da operacao
         expect(header[26..45]).to eq santander_cnab400.info_conta   # informacoes da conta
-        expect(header[76..78]).to eq '033'                     # codigo do banco
+        expect(header[76..78]).to eq '033'                          # codigo do banco
+        expect(header[100..115]).to eq ''.rjust(16, "0")            # zeros
+        expect(header[116..390]).to eq ''.rjust(275,' ')            # campos mensagens vazios
+        expect(header[391..393]).to eq '058'                        # numero da versão da remessa
       end
     end
 


### PR DESCRIPTION
Foram realizados os ajustes sugeridos pelo relatório de homologação.
Sendo: 
- 16 zeros após a data
- Indicar se é utilizada conta do padrão novo (10 caracteres com DV).
- Informar o total de linhas do arquivo no campo requerido do Santander.
