### PR TITLE
Campo numérico passa a receber zeros a esquerda

### DIFF
--- a/lib/brcobranca/remessa/cnab400/santander.rb
+++ b/lib/brcobranca/remessa/cnab400/santander.rb
@@ -37,7 +37,7 @@ module Brcobranca
         def info_conta
           # CAMPO                     TAMANHO
           # codigo_transmissao        20
-          codigo_transmissao.rjust(20, ' ')
+          codigo_transmissao.strip.rjust(20, '0')
         end
 
         # Zeros do header

--- a/lib/brcobranca/remessa/cnab400/santander.rb
+++ b/lib/brcobranca/remessa/cnab400/santander.rb
@@ -30,6 +30,10 @@ module Brcobranca
           'SANTANDER'.format_size(15)
         end
 
+        def codigo_transmissao=(valor)
+          @codigo_transmissao = valor.to_s.strip.rjust(20, '0') if valor
+        end
+
         # Informacoes do Código de Transmissão
         #
         # @return [String]
@@ -37,7 +41,7 @@ module Brcobranca
         def info_conta
           # CAMPO                     TAMANHO
           # codigo_transmissao        20
-          codigo_transmissao.strip.rjust(20, '0')
+          codigo_transmissao
         end
 
         # Zeros do header

--- a/spec/brcobranca/remessa/cnab400/santander_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/santander_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
         expect(object.errors.full_messages).to include('Codigo transmissao não pode estar em branco.')
       end
 
-      it 'deve ser invalido se o deve ter no máximo 20 dígitos.' do
+      it 'deve ser invalido se o codigo de transmissao ter mais de 20 dígitos.' do
         santander.codigo_transmissao = '123456789012345678901'
         expect(santander.invalid?).to be true
         expect(santander.errors.full_messages).to include('Codigo transmissao deve ter no máximo 20 dígitos.')
@@ -91,6 +91,11 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
       info_conta = santander.info_conta
       expect(info_conta.size).to eq 20
       expect(info_conta[0..19]).to eq '17777751042700080112' # codigo_transmissao
+
+      object = subject.class.new(params.merge!(codigo_transmissao: '7777751042700080112'))
+      info_conta = object.info_conta
+      expect(info_conta.size).to eq 20
+      expect(info_conta[0..19]).to eq '07777751042700080112' # codigo_transmissao
     end
   end
 


### PR DESCRIPTION
O campo código da transmissão deve ser preenchido com zeros a esquerda e não com espaçamento.
