### PR TITLE
Corrige cálculo gerador do dígito verificador da conta.

### DIFF
--- a/lib/brcobranca/boleto/sicoob.rb
+++ b/lib/brcobranca/boleto/sicoob.rb
@@ -35,6 +35,12 @@ module Brcobranca
         @agencia = valor.to_s.rjust(4, "0") if valor
       end
 
+      # Dígito verificador da agência
+      # @return [Integer] 1 caracteres numéricos.
+      def agencia_dv
+        agencia.modulo11(mapeamento: { 10 => '0' }).to_s
+      end
+
       # Convênio
       #
       # @return [String] 7 caracteres numéricos.

--- a/lib/brcobranca/remessa/cnab240/sicoob.rb
+++ b/lib/brcobranca/remessa/cnab240/sicoob.rb
@@ -74,7 +74,7 @@ module Brcobranca
         def digito_agencia
           # utilizando a agencia com 4 digitos
           # para calcular o digito
-          agencia.modulo11(mapeamento: { 10 => 'X' }).to_s
+          agencia.modulo11(mapeamento: { 10 => '0' }).to_s
         end
 
         def digito_conta

--- a/spec/brcobranca/remessa/cnab240/sicoob_spec.rb
+++ b/spec/brcobranca/remessa/cnab240/sicoob_spec.rb
@@ -113,6 +113,18 @@ RSpec.describe Brcobranca::Remessa::Cnab240::Sicoob do
       # =         36 24 14 6 = 80
       # 80 / 11 = 7 com resto 3
       expect(sicoob.digito_agencia).to eq '3'
+
+      sicoob_2 = subject.class.new(params.merge!(agencia: '3214'))
+      expect(sicoob_2.digito_agencia).to eq '0'
+
+      sicoob_3 = subject.class.new(params.merge!(agencia: '0001'))
+      expect(sicoob_3.digito_agencia).to eq '9'
+
+      sicoob_4 = subject.class.new(params.merge!(agencia: '2006'))
+      expect(sicoob_4.digito_agencia).to eq '0'
+
+      sicoob_5 = subject.class.new(params.merge!(agencia: '3032'))
+      expect(sicoob_5.digito_agencia).to eq '5'
     end
 
     it 'deve calcular  digito da conta' do


### PR DESCRIPTION
Estava errado o mapeamento da sobra com valor 10, deveria ser '0' e estava como 'X'
na remessa, já o boleto pegava o cálculo padrão da classe base, e não tratava essa sobra.