### PR TITLE
Permite que seja alterado o valor da conta movimento.

### DIFF
--- a/lib/brcobranca/remessa/cnab400/santander.rb
+++ b/lib/brcobranca/remessa/cnab400/santander.rb
@@ -11,6 +11,7 @@ module Brcobranca
         attr_accessor :codigo_transmissao
 
         attr_accessor :codigo_carteira
+        attr_accessor :conta_movimento
 
         validates_presence_of :documento_cedente, :codigo_transmissao
         validates_presence_of :digito_conta, if: :conta_padrao_novo?
@@ -104,8 +105,8 @@ module Brcobranca
           detalhe = '1'                                                     # identificacao transacao               9[01]
           detalhe << Brcobranca::Util::Empresa.new(documento_cedente).tipo  # tipo de identificacao da empresa      9[02]
           detalhe << documento_cedente.to_s.rjust(14, '0')                  # cpf/cnpj da empresa                   9[14]
-          detalhe << codigo_transmissao                                     # Código de Transmissão                 9[20]
-          detalhe << pagamento.documento_ou_numero.to_s.ljust(25, ' ')                                      # identificacao do tit. na empresa      X[25]
+          detalhe << agencia_conta_movimento                                # conta corrente                        9[20]
+          detalhe << pagamento.documento_ou_numero.to_s.ljust(25, ' ')      # identificacao do tit. na empresa      X[25]
           detalhe << pagamento.nosso_numero.to_s.rjust(8, '0')              # nosso numero                          9[8]
           detalhe << pagamento.formata_data_segundo_desconto                # data limite para o segundo desconto   9[06]
           detalhe << ''.rjust(1, ' ')                                       # brancos                               X[1]
@@ -186,6 +187,11 @@ module Brcobranca
           detalhe << ''.rjust(1, ' ')                                       # Brancos                               X[1]
           detalhe << sequencial.to_s.rjust(6, '0')                          # numero do registro no arquivo         9[06]
           detalhe
+        end
+
+        def agencia_conta_movimento
+          return codigo_transmissao if conta_movimento.nil?
+          "#{agencia}#{conta_movimento[0..7]}#{conta_corrente[0..7]}"
         end
 
         def identificador_movimento_complemento

--- a/spec/brcobranca/remessa/cnab400/santander_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/santander_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
         header = santander.monta_header
         expect(header[1]).to eq '1'                                 # tipo operacao (1 = remessa)
         expect(header[2..8]).to eq 'REMESSA'                        # literal da operacao
-        expect(header[26..45]).to eq santander.info_conta   # informacoes da conta
+        expect(header[26..45]).to eq santander.info_conta           # informacoes da conta
         expect(header[76..78]).to eq '033'                          # codigo do banco
         expect(header[100..115]).to eq ''.rjust(16, "0")            # zeros
         expect(header[116..390]).to eq ''.rjust(275,' ')            # campos mensagens vazios
@@ -123,12 +123,22 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Santander do
     context 'detalhe' do
       it 'informacoes devem estar posicionadas corretamente no detalhe' do
         detalhe = santander.monta_detalhe pagamento, 1
-        expect(detalhe[37..61]).to eq "6969".ljust(25) # nosso numero
-        expect(detalhe[62..69]).to eq '00000123' # nosso numero
-        expect(detalhe[120..125]).to eq Date.today.strftime('%d%m%y') # data de vencimento
-        expect(detalhe[126..138]).to eq '0000000019990' # valor do titulo
-        expect(detalhe[220..233]).to eq '00012345678901' # documento do pagador
-        expect(detalhe[234..263]).to eq 'PABLO DIEGO JOSE FRANCISCO DE ' # nome do pagador
+        expect(detalhe[17..36]).to eq "17777751042700080112"              # agencia + conta
+        expect(detalhe[37..61]).to eq "6969".ljust(25)                    # nosso numero
+        expect(detalhe[62..69]).to eq '00000123'                          # nosso numero
+        expect(detalhe[120..125]).to eq Date.today.strftime('%d%m%y')     # data de vencimento
+        expect(detalhe[126..138]).to eq '0000000019990'                   # valor do titulo
+        expect(detalhe[220..233]).to eq '00012345678901'                  # documento do pagador
+        expect(detalhe[234..263]).to eq 'PABLO DIEGO JOSE FRANCISCO DE '  # nome do pagador
+      end
+
+      it 'adiciona a conta de movimento quando informada' do
+        santander.agencia = "1777"
+        santander.conta_movimento = "012000123"
+        santander.conta_corrente = "00080112"
+
+        detalhe = santander.monta_detalhe pagamento, 1
+        expect(detalhe[17..36]).to eq "17770120001200080112"              # agencia + conta
       end
     end
 


### PR DESCRIPTION
Algumas contas movimento são diferentes das que constam no código de transmissão, dessa forma é possível adicionar esse valor, quando necessário. Também garente que não quebra compatibilidade na forma de uso anterior.