### PR TITLE
Obriga documento do cedente no CrediSiS

### DIFF
--- a/lib/brcobranca/remessa/cnab400/credisis.rb
+++ b/lib/brcobranca/remessa/cnab400/credisis.rb
@@ -19,7 +19,7 @@ module Brcobranca
         attr_accessor :codigo_cedente
 
         validates_presence_of :agencia, :conta_corrente, :digito_conta, :parcela,
-                              :convenio, :sequencial_remessa
+                              :convenio, :sequencial_remessa, :documento_cedente
         validates_length_of :convenio, maximum: 6
         validates_length_of :agencia, maximum: 4
         validates_length_of :conta_corrente, maximum: 8
@@ -90,6 +90,7 @@ module Brcobranca
         # @return [String]
         #
         def monta_detalhe(pagamento, sequencial)
+          pagamento.validar_numero_sacado = true
           fail Brcobranca::RemessaInvalida.new(pagamento) if pagamento.invalid?
 
           detalhe = '1'                                                     # identificacao transacao               9[01]

--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -94,10 +94,12 @@ module Brcobranca
       attr_accessor :codigo_baixa
       # <b>OPCIONAL</b>: dias para baixa
       attr_accessor :dias_baixa
+      attr_accessor :validar_numero_sacado
 
       validates_presence_of :nosso_numero, :data_vencimento, :valor,
                             :documento_sacado, :nome_sacado, :logradouro_sacado,
-                            :numero_sacado, :cep_sacado, :cidade_sacado, :uf_sacado
+                            :cep_sacado, :cidade_sacado, :uf_sacado
+      validates_presence_of :numero_sacado, if: :validar_numero_sacado
       validates_length_of :cep_sacado, is: 8
       validates_length_of :cod_desconto, is: 1
       validates_length_of :cod_segundo_desconto, is: 1
@@ -130,7 +132,8 @@ module Brcobranca
           codigo_baixa: '0',
           dias_baixa: '000',
           cod_primeira_instrucao: '00',
-          cod_segunda_instrucao: '00'
+          cod_segunda_instrucao: '00',
+          validar_numero_sacado: false
         }
 
         campos = padrao.merge!(campos)

--- a/spec/brcobranca/remessa/cnab400/credisis_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/credisis_spec.rb
@@ -125,6 +125,23 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis do
         end
       end
     end
+
+    describe '#documento_cedente' do
+      context 'com valor nil' do
+        let(:credisis) { described_class.new(params.merge!(documento_cedente: nil)) }
+
+        it do
+          expect(credisis.invalid?).to be true
+          expect(credisis.errors.full_messages).to include('Documento cedente não pode estar em branco.')
+        end
+      end
+
+      context 'com valor válido' do
+        let(:credisis) { subject.class.new(params.merge!(sequencial_remessa: '36136903825')) }
+
+        it { expect(credisis.invalid?).to be true }
+      end
+    end
   end
 
   context 'formatacoes dos valores' do

--- a/spec/brcobranca/remessa/cnab400/credisis_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/credisis_spec.rb
@@ -137,9 +137,9 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis do
       end
 
       context 'com valor válido' do
-        let(:credisis) { subject.class.new(params.merge!(sequencial_remessa: '36136903825')) }
+        let(:credisis) { subject.class.new(params.merge!(documento_cedente: '36136903825')) }
 
-        it { expect(credisis.invalid?).to be true }
+        it { expect(credisis.invalid?).to be false }
       end
     end
   end

--- a/spec/brcobranca/remessa/pagamento_spec.rb
+++ b/spec/brcobranca/remessa/pagamento_spec.rb
@@ -54,10 +54,23 @@ RSpec.describe Brcobranca::Remessa::Pagamento do
       expect(pagamento.errors.full_messages).to include('Logradouro sacado não pode estar em branco.')
     end
 
-    it 'deve ser inválido se não possuir número do sacado' do
-      pagamento.numero_sacado = nil
-      expect(pagamento.invalid?).to be true
-      expect(pagamento.errors.full_messages).to include('Numero sacado não pode estar em branco.')
+    describe '#validar_numero_sacado' do
+      before { pagamento.numero_sacado = nil }
+
+      context 'ativado' do
+        before { pagamento.validar_numero_sacado = true }
+
+        it do
+          expect(pagamento.invalid?).to be true
+          expect(pagamento.errors.full_messages).to include('Numero sacado não pode estar em branco.')
+        end
+      end
+
+      context 'desativado' do
+        before { pagamento.validar_numero_sacado = false }
+
+        it { expect(pagamento.invalid?).to be false }
+      end
     end
 
     it 'deve ser inválido se não possuir cidade do sacado' do


### PR DESCRIPTION
No CrediSiS esse campo é obrigatório, mudei tbm a obrigação do numero do endereço do sacado, agora só vai obrigar esse campo no CrediSiS para não dar problema em outros bancos, já que antes era assim.

