### PR TITLE
Altera forma de validar os pagamentos na remessa do credsis

### DIFF
--- a/lib/brcobranca/remessa/cnab400/credisis.rb
+++ b/lib/brcobranca/remessa/cnab400/credisis.rb
@@ -48,6 +48,13 @@ module Brcobranca
           @carteira = valor.to_s.rjust(2, '0') if valor
         end
 
+        def pagamentos=(valor)
+          @pagamentos = (valor || []).map do |pagamento|
+            pagamento[:validar_numero_sacado] = true
+            pagamento
+          end
+        end
+
         def cod_banco
           '097'
         end
@@ -90,7 +97,6 @@ module Brcobranca
         # @return [String]
         #
         def monta_detalhe(pagamento, sequencial)
-          pagamento.validar_numero_sacado = true
           fail Brcobranca::RemessaInvalida.new(pagamento) if pagamento.invalid?
 
           detalhe = '1'                                                     # identificacao transacao               9[01]

--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -138,7 +138,7 @@ module Brcobranca
 
         campos = padrao.merge!(campos)
         campos.each do |campo, valor|
-          send "#{campo}=", valor
+          self[campo] = valor
         end
 
         yield self if block_given?
@@ -156,6 +156,10 @@ module Brcobranca
         else
           '00000000'
         end
+      end
+
+      def []=(campo, valor)
+        send "#{campo}=", valor
       end
 
       # Formata a data de segundo desconto de acordo com o formato passado

--- a/spec/brcobranca/remessa/cnab400/credisis_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/credisis_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis do
     context "quando o campo validar_numero_sacado é falso" do
       before { pagamento.validar_numero_sacado = false }
 
-      it "seta valor para verdadeiro" do
+      it "altera valor para verdadeiro" do
         expect(credisis.pagamentos.first.validar_numero_sacado).to be true
       end
     end

--- a/spec/brcobranca/remessa/cnab400/credisis_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/credisis_spec.rb
@@ -144,6 +144,16 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis do
     end
   end
 
+  describe "pagamentos=" do
+    context "quando o campo validar_numero_sacado é falso" do
+      before { pagamento.validar_numero_sacado = false }
+
+      it 'seta valor para verdadeiro' do
+        expect(credisis.pagamentos.first.validar_numero_sacado).to be true
+      end
+    end
+  end
+
   context 'formatacoes dos valores' do
     it 'cod_banco deve ser 097' do
       expect(credisis.cod_banco).to eq '097'

--- a/spec/brcobranca/remessa/cnab400/credisis_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/credisis_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis do
     context "quando o campo validar_numero_sacado é falso" do
       before { pagamento.validar_numero_sacado = false }
 
-      it 'seta valor para verdadeiro' do
+      it "seta valor para verdadeiro" do
         expect(credisis.pagamentos.first.validar_numero_sacado).to be true
       end
     end


### PR DESCRIPTION
Existe uma validação no base que chama o método `valid?` de cada pagamento e retorna as mensagens  pro monde-web, mudei a abordagem, setando a flag `validar_numero_sacado` no setter dos pagamentos no CrediSiS:
![Sem título](https://user-images.githubusercontent.com/3708060/65882721-f1d84880-e36b-11e9-9583-20536fa4ccef.png)