### PR TITLE
Renomeia propriedade tipo_mora para codigo_mora e remove codigo_juros

### DIFF
--- a/lib/brcobranca/remessa/cnab240/banco_brasil.rb
+++ b/lib/brcobranca/remessa/cnab240/banco_brasil.rb
@@ -229,7 +229,7 @@ module Brcobranca
           segmento_p << especie_titulo(pagamento)                       # especie do titulo                     2
           segmento_p << aceite                                          # aceite                                1
           segmento_p << pagamento.data_emissao.strftime('%d%m%Y')       # data de emissao titulo                8
-          segmento_p << pagamento.codigo_mora                           # cod. do juros                         1
+          segmento_p << pagamento.codigo_mora                           # cod. da mora                          1
           segmento_p << data_mora(pagamento)                            # data juros                            8
           segmento_p << pagamento.formata_valor_mora(15)                # valor juros                           15
           segmento_p << pagamento.cod_desconto                          # cod. do desconto                      1

--- a/lib/brcobranca/remessa/cnab240/banco_brasil.rb
+++ b/lib/brcobranca/remessa/cnab240/banco_brasil.rb
@@ -229,7 +229,7 @@ module Brcobranca
           segmento_p << especie_titulo(pagamento)                       # especie do titulo                     2
           segmento_p << aceite                                          # aceite                                1
           segmento_p << pagamento.data_emissao.strftime('%d%m%Y')       # data de emissao titulo                8
-          segmento_p << pagamento.tipo_mora                             # cod. do juros                         1
+          segmento_p << pagamento.codigo_mora                           # cod. do juros                         1
           segmento_p << data_mora(pagamento)                            # data juros                            8
           segmento_p << pagamento.formata_valor_mora(15)                # valor juros                           15
           segmento_p << pagamento.cod_desconto                          # cod. do desconto                      1

--- a/lib/brcobranca/remessa/cnab240/base.rb
+++ b/lib/brcobranca/remessa/cnab240/base.rb
@@ -193,7 +193,7 @@ module Brcobranca
           segmento_p << especie_titulo(pagamento)                       # especie do titulo                     2
           segmento_p << aceite                                          # aceite                                1
           segmento_p << pagamento.data_emissao.strftime('%d%m%Y')       # data de emissao titulo                8
-          segmento_p << pagamento.tipo_mora                             # cod. do mora                          1
+          segmento_p << pagamento.codigo_mora                           # cod. do mora                          1
           segmento_p << data_mora(pagamento)                            # data mora                             8
           segmento_p << pagamento.formata_valor_mora(15)                # valor mora                            15
           segmento_p << codigo_desconto(pagamento)                      # cod. do desconto                      1
@@ -527,7 +527,7 @@ module Brcobranca
         end
 
         def data_mora(pagamento)
-          return ''.rjust(8, '0') unless %w( 1 2 ).include? pagamento.tipo_mora
+          return ''.rjust(8, '0') unless %w( 1 2 ).include? pagamento.codigo_mora
 
           pagamento.formata_data_vencimento
         end

--- a/lib/brcobranca/remessa/cnab240/base.rb
+++ b/lib/brcobranca/remessa/cnab240/base.rb
@@ -193,7 +193,7 @@ module Brcobranca
           segmento_p << especie_titulo(pagamento)                       # especie do titulo                     2
           segmento_p << aceite                                          # aceite                                1
           segmento_p << pagamento.data_emissao.strftime('%d%m%Y')       # data de emissao titulo                8
-          segmento_p << pagamento.codigo_mora                           # cod. do mora                          1
+          segmento_p << pagamento.codigo_mora                           # cod. da mora                          1
           segmento_p << data_mora(pagamento)                            # data mora                             8
           segmento_p << pagamento.formata_valor_mora(15)                # valor mora                            15
           segmento_p << codigo_desconto(pagamento)                      # cod. do desconto                      1

--- a/lib/brcobranca/remessa/cnab240/caixa.rb
+++ b/lib/brcobranca/remessa/cnab240/caixa.rb
@@ -164,7 +164,7 @@ module Brcobranca
         end
 
         def data_mora(pagamento)
-          return ''.rjust(8, '0') unless %w[1 2].include? pagamento.tipo_mora
+          return ''.rjust(8, '0') unless %w[1 2].include? pagamento.codigo_mora
 
           pagamento.formata_proximo_dia_apos_data_vencimento
         end

--- a/lib/brcobranca/remessa/cnab240/sicoob.rb
+++ b/lib/brcobranca/remessa/cnab240/sicoob.rb
@@ -197,7 +197,7 @@ module Brcobranca
         end
 
         def data_mora(pagamento)
-          return ''.rjust(8, '0') unless %w[1 2].include? pagamento.tipo_mora
+          return ''.rjust(8, '0') unless %w[1 2].include? pagamento.codigo_mora
 
           pagamento.formata_proximo_dia_apos_data_vencimento
         end

--- a/lib/brcobranca/remessa/cnab240/sicredi.rb
+++ b/lib/brcobranca/remessa/cnab240/sicredi.rb
@@ -193,7 +193,7 @@ module Brcobranca
         end
 
         def data_mora(pagamento)
-          return ''.rjust(8, '0') unless %w( 1 2 ).include? pagamento.tipo_mora
+          return ''.rjust(8, '0') unless %w( 1 2 ).include? pagamento.codigo_mora
 
           pagamento.formata_proximo_dia_apos_data_vencimento
         end

--- a/lib/brcobranca/remessa/cnab400/banrisul.rb
+++ b/lib/brcobranca/remessa/cnab400/banrisul.rb
@@ -134,8 +134,8 @@ module Brcobranca
         end
 
         def tipo_mora(pagamento)
-          return ' ' if pagamento.tipo_mora == '3'
-          pagamento.tipo_mora
+          return ' ' if pagamento.codigo_mora == '3'
+          pagamento.codigo_mora
         end
 
         def formata_percentual_multa(pagamento)
@@ -145,7 +145,7 @@ module Brcobranca
         end
 
         def formata_valor_mora(tamanho, pagamento)
-          return ''.rjust(tamanho, ' ') if pagamento.tipo_mora == '3'
+          return ''.rjust(tamanho, ' ') if pagamento.codigo_mora == '3'
           pagamento.formata_valor_mora(tamanho)
         end
       end

--- a/lib/brcobranca/remessa/cnab400/credisis.rb
+++ b/lib/brcobranca/remessa/cnab400/credisis.rb
@@ -189,7 +189,7 @@ module Brcobranca
           detalhe << instrucoes.format_size(99)                            # instrucoes                            A[100]
           detalhe << ' '                                                    # brancos                               X[01]
           detalhe << pagamento.formata_valor_mora(15)                       # valor juros                           V[15]
-          detalhe << CODIGOS_MORA[pagamento.codigo_juros]                   # codigo tipo do juros                  A[01]
+          detalhe << CODIGOS_MORA[pagamento.codigo_mora]                    # codigo tipo do juros                  A[01]
           detalhe << '2'                                                    # tipo carência do juros                9[01]
           detalhe << '00'                                                   # dias carência do juros                9[01]
           detalhe << pagamento.formata_percentual_multa(15)                 # valor multa                           V[15]

--- a/lib/brcobranca/remessa/cnab400/credisis.rb
+++ b/lib/brcobranca/remessa/cnab400/credisis.rb
@@ -189,7 +189,7 @@ module Brcobranca
           detalhe << instrucoes.format_size(99)                            # instrucoes                            A[100]
           detalhe << ' '                                                    # brancos                               X[01]
           detalhe << pagamento.formata_valor_mora(15)                       # valor juros                           V[15]
-          detalhe << CODIGOS_MORA[pagamento.codigo_mora]                    # codigo tipo do juros                  A[01]
+          detalhe << CODIGOS_MORA[pagamento.codigo_mora]                    # codigo tipo da mora                   A[01]
           detalhe << '2'                                                    # tipo carência do juros                9[01]
           detalhe << '00'                                                   # dias carência do juros                9[01]
           detalhe << pagamento.formata_percentual_multa(15)                 # valor multa                           V[15]

--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -84,12 +84,10 @@ module Brcobranca
       attr_accessor :percentual_multa
       # <b>OPCIONAL</b>: Data para cobrança de multa
       attr_accessor :data_multa
-      # <b>OPCIONAL</b>: tipo de mora (diário, mensal)
-      attr_accessor :tipo_mora
+      # <b>OPCIONAL</b>: codigo tipo de mora (diário, mensal)
+      attr_accessor :codigo_mora
       # <b>OPCIONAL</b>: Data para cobrança de mora
       attr_accessor :data_mora
-      # <b>OPCIONAL</b>: codigo dos juros
-      attr_accessor :codigo_juros
       # <b>OPCIONAL</b>: codigo do protesto
       attr_accessor :codigo_protesto
       # <b>OPCIONAL</b>: dias para protesto
@@ -119,7 +117,7 @@ module Brcobranca
           data_emissao: Date.current,
           data_segundo_desconto: '00-00-00',
           data_terceiro_desconto: '00-00-00',
-          tipo_mora: '3',
+          codigo_mora: '3',
           valor_mora: 0.0,
           valor_desconto: 0.0,
           valor_segundo_desconto: 0.0,

--- a/spec/brcobranca/remessa/cnab240/caixa_spec.rb
+++ b/spec/brcobranca/remessa/cnab240/caixa_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Brcobranca::Remessa::Cnab240::Caixa do
                                        bairro_sacado: 'São josé dos quatro apostolos magros',
                                        cep_sacado: '12345678',
                                        cidade_sacado: 'Santa rita de cássia maria da silva',
-                                       tipo_mora: '1',
+                                       codigo_mora: '1',
                                        codigo_multa: '2',
                                        uf_sacado: 'SP',
                                        especie_titulo: 'RC')

--- a/spec/brcobranca/remessa/cnab240/sicoob_spec.rb
+++ b/spec/brcobranca/remessa/cnab240/sicoob_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Brcobranca::Remessa::Cnab240::Sicoob do
       cep_sacado: '12345678',
       cidade_sacado: 'Santa rita de cássia maria da silva',
       uf_sacado: 'RJ',
-      tipo_mora: '1',
+      codigo_mora: '1',
       codigo_protesto: '1',
       especie_titulo: 'DSI',
       codigo_multa: '1'
@@ -203,7 +203,7 @@ RSpec.describe Brcobranca::Remessa::Cnab240::Sicoob do
     end
 
     it 'data de mora deve ser após o vencimento quando informada e tipo de mora for 2' do
-      pagamento.tipo_mora = '2'
+      pagamento.codigo_mora = '2'
       segmento_p = sicoob.monta_segmento_p(pagamento, 1, 2)
 
       expect(segmento_p[77..84]).to eql '14072015'
@@ -211,7 +211,7 @@ RSpec.describe Brcobranca::Remessa::Cnab240::Sicoob do
     end
 
     it 'data de mora deve estar zerada caso tipo de mora seja 1 ou 2' do
-      pagamento.tipo_mora = '0'
+      pagamento.codigo_mora = '0'
       segmento_p = sicoob.monta_segmento_p(pagamento, 1, 2)
 
       expect(segmento_p[118..125]).to eql '00000000'

--- a/spec/brcobranca/remessa/cnab240/sicredi_spec.rb
+++ b/spec/brcobranca/remessa/cnab240/sicredi_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Brcobranca::Remessa::Cnab240::Sicredi do
     Brcobranca::Remessa::Pagamento.new(
       valor: 50.0,
       data_vencimento: Date.today,
-      tipo_mora: '1',
+      codigo_mora: '1',
       nosso_numero: '072000031',
       numero: '00003',
       documento: 6969,

--- a/spec/brcobranca/remessa/cnab400/credisis_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/credisis_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis, type: :model do
                                        nosso_numero: 123,
                                        documento: 6969,
                                        dias_protesto: '6',
+                                       codigo_mora: '2',
                                        valor_mora: '8.00',
+                                       codigo_multa: '2',
                                        percentual_multa: '2.00',
                                        documento_sacado: '12345678901',
                                        nome_sacado: 'PABLO DIEGO JOSÉ FRANCISCO DE PAULA JUAN NEPOMUCENO MARÍA DE LOS REMEDIOS CIPRIANO DE LA SANTÍSSIMA TRINIDAD RUIZ Y PICASSO',
@@ -18,9 +20,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis, type: :model do
                                        bairro_sacado: 'São josé dos quatro apostolos magros',
                                        cep_sacado: '12345678',
                                        cidade_sacado: 'Santa rita de cássia maria da silva',
-                                       uf_sacado: 'SP',
-                                       codigo_juros: '2',
-                                       codigo_multa: '2')
+                                       uf_sacado: 'SP')
   end
   let(:params) do
     {


### PR DESCRIPTION
Tinha uma propriedade `codigo_juros` que não estava sendo usada, isso acabou me confundindo, pq o campo certo era o `tipo_mora`, daí ja renomeei para `codigo_mora` para seguir o padrão dos outros campos.