### PR TITLE
Ajustes remessa CrediSiS

### DIFF
--- a/lib/brcobranca/remessa/base.rb
+++ b/lib/brcobranca/remessa/base.rb
@@ -56,6 +56,8 @@ module Brcobranca
 
         campos = { aceite: 'N' }.merge!(campos)
         campos.each do |campo, valor|
+          next unless respond_to? "#{campo}="
+
           send "#{campo}=", valor
         end
 

--- a/lib/brcobranca/remessa/cnab400/base.rb
+++ b/lib/brcobranca/remessa/cnab400/base.rb
@@ -73,7 +73,7 @@ module Brcobranca
           pagamentos.each do |pagamento|
             contador += 1
             ret << monta_detalhe(pagamento, contador)
-            if gera_detalhe_multa?
+            if gera_detalhe_multa?(pagamento)
               contador += 1
               ret << monta_detalhe_opcional(pagamento, contador)
             end
@@ -118,7 +118,7 @@ module Brcobranca
           '01'
         end
 
-        def gera_detalhe_multa?
+        def gera_detalhe_multa?(_pagamento)
           false
         end
 

--- a/lib/brcobranca/remessa/cnab400/credisis.rb
+++ b/lib/brcobranca/remessa/cnab400/credisis.rb
@@ -43,7 +43,6 @@ module Brcobranca
         attr_accessor :convenio
         attr_accessor :parcela
         attr_accessor :codigo_cedente
-        attr_accessor :instrucoes
 
         validates_presence_of :agencia, :conta_corrente, :digito_conta, :parcela,
                               :convenio, :sequencial_remessa, :documento_cedente, :nome_cedente,
@@ -55,14 +54,12 @@ module Brcobranca
         validates_length_of :carteira, maximum: 2
         validates_length_of :digito_conta, maximum: 1
         validates_length_of :sequencial_remessa, maximum: 7
-        validates_length_of :instrucoes, maximum: 100
 
         # Nova instancia do CrediSIS
         def initialize(campos = {})
           campos = {
             aceite: 'N',
-            parcela: '01',
-            instrucoes: ''
+            parcela: '01'
           }.merge!(campos)
           super(campos)
         end
@@ -184,9 +181,9 @@ module Brcobranca
           detalhe << bairro_cedente.format_size(25)                         # bairro do sacador/avalista            A[35]
           detalhe << cidade_cedente.format_size(25)                         # cidade do sacador/avalista            A[25]
           detalhe << uf_cedente.format_size(2)                              # uf do sacador/avalista                A[02]
-          detalhe << cep_cedente.format_size(8)                              # uf do sacador/avalista                A[02]
+          detalhe << cep_cedente.format_size(8)                             # uf do sacador/avalista                A[02]
           detalhe << ' '                                                    # brancos                               X[01]
-          detalhe << instrucoes.format_size(99)                            # instrucoes                            A[100]
+          detalhe << pagamento.instrucoes_boleto.format_size(99)            # instrucoes                            A[100]
           detalhe << ' '                                                    # brancos                               X[01]
           detalhe << pagamento.formata_valor_mora(15)                       # valor juros                           V[15]
           detalhe << CODIGOS_MORA[pagamento.codigo_mora]                    # codigo tipo da mora                   A[01]
@@ -263,8 +260,8 @@ module Brcobranca
           documento_cedente.modulo11(mapeamento: Boleto::Credisis::MAPEAMENTO_MODULO11)
         end
 
-        def gera_detalhe_multa?
-          !instrucoes.blank?
+        def gera_detalhe_multa?(pagamento)
+          !pagamento.instrucoes_boleto.blank?
         end
       end
     end

--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -96,6 +96,8 @@ module Brcobranca
       attr_accessor :codigo_baixa
       # <b>OPCIONAL</b>: dias para baixa
       attr_accessor :dias_baixa
+      # <b>OPCIONAL</b>: instruções boleto
+      attr_accessor :instrucoes_boleto
       attr_accessor :validar_numero_sacado
 
       validates_presence_of :nosso_numero, :data_vencimento, :valor,
@@ -137,7 +139,8 @@ module Brcobranca
           dias_baixa: '000',
           cod_primeira_instrucao: '00',
           cod_segunda_instrucao: '00',
-          validar_numero_sacado: false
+          validar_numero_sacado: false,
+          instrucoes_boleto: ''
         }
 
         campos = padrao.merge!(campos)

--- a/spec/brcobranca/remessa/base_spec.rb
+++ b/spec/brcobranca/remessa/base_spec.rb
@@ -21,9 +21,20 @@ RSpec.describe Brcobranca::Remessa::Base do
       conta_corrente: '1234',
       pagamentos: [pagamento] }
   end
-  let(:base) { subject.class.new(params) }
 
-  context 'validacoes' do
+  describe '#new' do
+    subject(:instance) { described_class.new(params) }
+
+    context 'with nonexistent properties' do
+      let(:params) { { a: 'a', b: 'b' } }
+
+      it 'initializes without errors' do
+        expect(instance).to be_an_instance_of(described_class)
+      end
+    end
+  end
+
+  describe 'validacoes' do
     context '@pagamentos' do
       it 'deve ser invalido se nao possuir ao menos um pagamento' do
         objeto = subject.class.new(params.merge!(pagamentos: nil))

--- a/spec/brcobranca/remessa/cnab400/credisis_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/credisis_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis, type: :model do
                                        bairro_sacado: 'São josé dos quatro apostolos magros',
                                        cep_sacado: '12345678',
                                        cidade_sacado: 'Santa rita de cássia maria da silva',
-                                       uf_sacado: 'SP')
+                                       uf_sacado: 'SP',
+                                       instrucoes_boleto: instrucoes_boleto)
   end
   let(:params) do
     {
@@ -43,6 +44,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis, type: :model do
       pagamentos: [pagamento]
     }
   end
+  let(:instrucoes_boleto) { '' }
   let(:credisis) { described_class.new(params) }
 
   describe 'validações' do
@@ -66,7 +68,6 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis, type: :model do
     it { is_expected.to validate_presence_of(:cidade_cedente) }
     it { is_expected.to validate_presence_of(:uf_cedente) }
     it { is_expected.not_to validate_presence_of(:complemento_cedente) }
-    it { is_expected.not_to validate_presence_of(:instrucoes) }
   end
 
   describe "pagamentos=" do
@@ -159,7 +160,7 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Credisis, type: :model do
     describe '#monta_detalhe_opcional' do
       subject(:detalhe) { credisis.monta_detalhe_opcional(pagamento, 1) }
 
-      let(:credisis) { described_class.new(params.merge!(instrucoes: 'PAGAR ANTES DO VENCIMENTO')) }
+      let(:instrucoes_boleto) { 'PAGAR ANTES DO VENCIMENTO' }
 
       it { expect(detalhe.size).to eq 400 }
       it { expect(detalhe[0]).to eq '2' }


### PR DESCRIPTION
Esse PR tem 2 alterações:
1 - Adiciona tratamento para que todas as classes de remessa não quebrem caso sejam inicializadas com parâmetros que não existem. Por que? No monde bancos tem todo um mecanismo para registrar em cada banco qual campo deve ir pro objeto e qual não, até onde eu entendi isso era pra apenas não quebrar a inicialização, só que toda vez que for adicionado um campo na API de remessa, vc tem que lembrar de abrir esse arquivo e ignorar as propriedades em todos os demais bancos que não forem utilizar: https://github.com/monde-sistemas/monde-bancos/blob/master/db/remessas_suportadas.yml.

2 - Fiz um pequeno ajuste passando o campo que contêm as instruções do boleto para o objeto de pagamento e não na remessa em si, isso tinha ficado despadronizado com os demais dados que vão nos pagamentos, e eu só percebi ao implementar o preenchimento no monde-bancos.