### PR TITLE
Adiciona tratamento de quebras de linhas e espaços nas instruções do boleto

### DIFF
--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/date/calculations'
 require 'active_support/core_ext/time/calculations'
+require 'active_support/core_ext/string'
 
 # -*- encoding: utf-8 -*-
 module Brcobranca
@@ -222,6 +223,10 @@ module Brcobranca
       def respond_to_missing?(method, include_private = false)
         name = method.to_s
         name.start_with?('formata_data') || name.start_with?('formata_valor') || super
+      end
+
+      def instrucoes_boleto=(valor)
+        @instrucoes_boleto = valor.to_s.squish
       end
 
       private

--- a/spec/brcobranca/remessa/pagamento_spec.rb
+++ b/spec/brcobranca/remessa/pagamento_spec.rb
@@ -283,4 +283,14 @@ RSpec.describe Brcobranca::Remessa::Pagamento do
       it { is_expected.to eq 'Wall street, 999' }
     end
   end
+
+  describe "#instrucoes_boleto=" do
+    subject! { pagamento.instrucoes_boleto = instrucoes }
+
+    context "com quebras de linhas e espaços" do
+      let(:instrucoes) { "A\n   B\nC\t"}
+
+      it { expect(pagamento.instrucoes_boleto).to eq "A B C"}
+    end
+  end
 end


### PR DESCRIPTION
Geralmente esse campo vem com quebras de linhas, mas pra ficar correto na remessa tem que remover as quebras e enviar separado com espaço, se não quebra a estrutura do arquivo, daí usei esse método mágico do ActiveSupport:
https://apidock.com/rails/String/squish 