### PR TITLE
Kodiak usa body do PR como body do commit

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -4,3 +4,7 @@ version = 1
 [merge]
 method = "squash"
 delete_branch_on_merge = true
+block_on_reviews_requested = true
+
+[merge.message]
+body = "pull_request_body" 


### PR DESCRIPTION
Concluímos que é melhor ter o body do PR no body do commit final de squash e não uma lista com o título de todos os commits. Tanto que já está documentado assim no playbook mas até então o bot não estava fazendo isso.

Isso foi discutido no https://github.com/monde-sistemas/monde-desktop/pull/1289 mas acabou sendo perdido.

Replicação do PR https://github.com/monde-sistemas/sig-web/pull/1403

Tbm adicionei a config block_on_reviews_requested que estava diferente dos demais repos;